### PR TITLE
Silence Notice on Windows

### DIFF
--- a/php5.3/SocketIO.class.php
+++ b/php5.3/SocketIO.class.php
@@ -84,7 +84,7 @@ class SocketIO {
 
 			$r = array($this->fd);
 			$w = null; $e = null;
-			$n = stream_select($r, $w, $e, 5);
+			$n = @stream_select($r, $w, $e, 5);
 			if ($n == 0) continue;
 
 			$this->prvHandleData();


### PR DESCRIPTION
Windows shows a notice:
Warning: Invalid CRT parameters detected

the @ silences this notice
